### PR TITLE
updates github-script to v6

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
     - run: echo PR Number Input - ${{ inputs.pull-number }}
       shell: bash
-    - uses: actions/github-script@v3
+    - uses: actions/github-script@v6
       id: get-pr
       env:
         REPO_OWNER: ${{ inputs.repo-owner }}


### PR DESCRIPTION
Suppresses the following warning by upgrading `github-script`

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/github-script
```